### PR TITLE
feat: add debounce to search filtering

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+
+export const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/src/pages/TodoListPage.tsx
+++ b/src/pages/TodoListPage.tsx
@@ -5,6 +5,7 @@ import { TodoItem } from '../components/todo/TodoItem'
 import { ROUTES } from '../constants/routes'
 import { STATUS_OPTIONS } from '../constants/todo'
 import { useAuth } from '../contexts/AuthContext'
+import { useDebounce } from '../hooks/useDebounce'
 import type { Status, Todo } from '../lib/database.types'
 import { supabase } from '../lib/supabase'
 
@@ -15,6 +16,7 @@ export const TodoListPage = () => {
   const [todos, setTodos] = useState<Todo[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
+  const debouncedQuery = useDebounce(searchQuery, 300)
   const [statusFilter, setStatusFilter] = useState<Status | 'all'>('all')
 
   useEffect(() => {
@@ -51,14 +53,14 @@ export const TodoListPage = () => {
   }, [user, statusFilter])
 
   const filteredTodos = useMemo(() => {
-    if (!searchQuery) return todos
-    const q = searchQuery.toLowerCase()
+    if (!debouncedQuery) return todos
+    const q = debouncedQuery.toLowerCase()
     return todos.filter(
       (todo) =>
         todo.title.toLowerCase().includes(q) ||
         (todo.description && todo.description.toLowerCase().includes(q)),
     )
-  }, [todos, searchQuery])
+  }, [todos, debouncedQuery])
 
   const handleStatusChange = async (todoId: string, status: Status) => {
     const { error } = await supabase.from('todos').update({ status }).eq('id', todoId)


### PR DESCRIPTION
## Summary
- 検索入力に300msのデバウンス処理を追加し、入力中の不要なフィルタリング実行を抑制
- 汎用的な `useDebounce` カスタムフックを新規作成
- `TodoListPage` の `filteredTodos` でデバウンス済みの検索クエリを使用するよう変更

## Test plan
- [ ] 検索入力欄に文字を素早く入力し、入力中はフィルタリングが実行されないことを確認
- [ ] 入力停止後約300msでフィルタリングが実行されることを確認
- [ ] 検索欄をクリアした際に全TODOが表示されることを確認
- [ ] ステータスフィルターとの併用が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)